### PR TITLE
Installation via Gemfile/bundler

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -6,8 +6,9 @@ separately in the same form and still saving them all at once in the same reques
 == Installation
 
 Batch translation supports Globalize 3 and is not backward compatible.
+Put the following line in your Gemfile and run <pre>bundle install</pre>.
 
-  rails plugin install git://github.com/fidel/batch_translations.git
+  gem 'batch_translations', :git => 'git://github.com/fruell/batch_translations.git'
 
 == Model configuration
 
@@ -19,11 +20,16 @@ place
 
   accepts_nested_attributes_for :translations
 
+and if you use <pre>attr_accessible</pre>
+
+  attr_accessible :translations_attributes
+
 so it'll look like
 
   class Post < ActiveRecord::Base
     translates :title, :teaser, :body
     accepts_nested_attributes_for :translations
+    attr_accessible :translations_attributes
   end
 
 It's necessary for proper working.

--- a/README.rdoc
+++ b/README.rdoc
@@ -6,7 +6,7 @@ separately in the same form and still saving them all at once in the same reques
 == Installation
 
 Batch translation supports Globalize 3 and is not backward compatible.
-Put the following line in your Gemfile and run <pre>bundle install</pre>.
+Put the following line in your Gemfile and run _bundle_ _install_.
 
   gem 'batch_translations', :git => 'git://github.com/fruell/batch_translations.git'
 
@@ -20,7 +20,7 @@ place
 
   accepts_nested_attributes_for :translations
 
-and if you use <pre>attr_accessible</pre>
+and if you use _attr_accessible_
 
   attr_accessible :translations_attributes
 

--- a/batch_translations.gemspec
+++ b/batch_translations.gemspec
@@ -1,0 +1,12 @@
+Gem::Specification.new do |s|
+  s.name        = 'batch_translations'
+  s.version     = '0.0.0'
+  s.date        = '2012-09-12'
+  s.summary     = "Helpers to allow saving multiple Globalize3 translations in the same request."
+  s.description = "Helper that renders globalize_translations fields on a per-locale basis, so you can use them separately in the same form and still saving them all at once in the same request."
+  s.authors     = ["Jose Alvarez Rilla", "Szymon Fiedler"]
+  s.email       = ''
+  s.files       =  Dir.glob("lib/**/*") + %w(init.rb README.rdoc)
+  s.homepage    = 'https://github.com/fidel/batch_translations'
+  s.add_dependency 'globalize3'
+end

--- a/lib/batch_translations.rb
+++ b/lib/batch_translations.rb
@@ -1,0 +1,7 @@
+# The actual plugin
+require 'batch_translation'
+
+# Dummy modul to keep backward compatibility but avoid additional require
+# in Gemfile
+module BatchTranslations
+end


### PR DESCRIPTION
Wrote a Gemspec so you can install via

`gem 'batch_translations', :git => 'git://github.com/fidel/batch_translations.git'`

without the dummy modul you would have to add a

`:require => 'batch_translation'`

which may confuse some (and renaming the file would break backward compatibility).
