### PR TITLE
Fix choosing right translations version

### DIFF
--- a/lib/batch_translation.rb
+++ b/lib/batch_translation.rb
@@ -6,7 +6,7 @@ module ActionView
 
         @index = @index ? @index + 1 : 1
         object_name = "#{@object_name}[translations_attributes][#{@index}]"
-        object = @object.translations.first { |t| t.locale == locale.to_sym }
+        object = @object.translations.find { |t| t.locale == locale.to_sym }
 
         @template.concat @template.hidden_field_tag("#{object_name}[id]", object ? object.id : "")
         @template.concat @template.hidden_field_tag("#{object_name}[locale]", locale)


### PR DESCRIPTION
Right now if you want to use `globalize_fields_for` for create/update form and your data be invalid, after render you :new/:edit template your changed translation fields data will be lost
